### PR TITLE
issue: #1: Translated déploiement to english

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,3 +17,4 @@ Pour commencer, nous recommendons de consulter la liste des [issues](https://git
 - Les pulls requests seront ensuite revues et traitées. L'issue associée sera mise à jour en conséquence.  
 - Les commentaires doivent contenir le numéro de l'issue.
 ol
+ololol

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,3 +16,4 @@ Pour commencer, nous recommendons de consulter la liste des [issues](https://git
 - Un contributeur doit forker le projet source puis pourra soumettre ces contributions via des pull requests.  
 - Les pulls requests seront ensuite revues et traitées. L'issue associée sera mise à jour en conséquence.  
 - Les commentaires doivent contenir le numéro de l'issue.
+ol

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A définir : expliquer comment executer les tests
 ```
 
 
-## Deployment
+## Déploiement
 
 Voici les étapes à suivre pour déployer en production :
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Merci de lire les fichiers :
 
 ## Auteurs
 
-* **Non spécifié**
+O. C
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+--Modification ici en remote--Modification ici en remote--Modification ici en remote--Modification ici en remote--Modification ici en remote--
 # Open Transport
 
 Application web pour covoiturage. 

--- a/README.md
+++ b/README.md
@@ -62,3 +62,4 @@ O. C
 Ce projet est sous la licence GNU GPL V3 - voir le fichier [LICENSE](LICENSE) pour plus de détails
 lolol
 --modified veersion of the project--modified veersion of the project--modified veersion of the project--modified veersion of the project--
+lol

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+"modifiying here in local"
 # Open Transport
 
 Application web pour covoiturage. 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 --Modification ici en remote--Modification ici en remote--Modification ici en remote--Modification ici en remote--Modification ici en remote--
 # Open Transport
+im remote and im adding some things here
 
 Application web pour covoiturage. 
 

--- a/README.md
+++ b/README.md
@@ -59,3 +59,5 @@ O. C
 ## License
 
 Ce projet est sous la licence GNU GPL V3 - voir le fichier [LICENSE](LICENSE) pour plus de détails
+
+--modified veersion of the project--modified veersion of the project--modified veersion of the project--modified veersion of the project--

--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ O. C
 ## License
 
 Ce projet est sous la licence GNU GPL V3 - voir le fichier [LICENSE](LICENSE) pour plus de détails
+lolol

--- a/README.md
+++ b/README.md
@@ -63,3 +63,4 @@ Ce projet est sous la licence GNU GPL V3 - voir le fichier [LICENSE](LICENSE) po
 lolol
 --modified veersion of the project--modified veersion of the project--modified veersion of the project--modified veersion of the project--
 lol
+ololol

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
---Modification ici en remote--Modification ici en remote--Modification ici en remote--Modification ici en remote--Modification ici en remote--
 # Open Transport
+---Modifying here in local--Modifying here in local--Modifying here in local--Modifying here in local-Modifying here in local
 
 Application web pour covoiturage. 
 


### PR DESCRIPTION
On the ReadMe file there was a section mistakingly named "Deployment" instead of "Déploiement". Since the ReadMe is in french, it should be written in french as well.