### PR TITLE
Correction auteur non-spécifié en "OC"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A définir : expliquer comment executer les tests
 ```
 
 
-## Deployment
+## Deploiement
 
 Voici les étapes à suivre pour déployer en production :
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Merci de lire les fichiers :
 
 ## Auteurs
 
-* **Non spécifié**
+* OC
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Merci de lire les fichiers :
 
 ## Auteurs
 
-* OC
+* **Non spécifié**
 
 ## License
 


### PR DESCRIPTION
Correction dans le README.md,  "non-spécifié" a été remplacé par "OC" pour indiquer l'auteur.