### PR TITLE
Fix typo in README.md #1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ C'est grâce à ce genre d'investissement que nous pourrons favoriser un covoitu
 
 Open Transport recherche des contributeurs pour tous types de tâches : améliorations, correction de bugs, nouvelles fonctionnalités.
 
-## Comment contriburer ?
+## Comment contribuer au projet ?
 
 
 Pour commencer, nous recommendons de consulter la liste des [issues](https://github.com/OpenClassrooms-Student-Center/7688581-Expert-Git-GitHub/issues)   

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ C'est grâce à ce genre d'investissement que nous pourrons favoriser un covoitu
 
 Open Transport recherche des contributeurs pour tous types de tâches : améliorations, correction de bugs, nouvelles fonctionnalités.
 
-## Comment contriburer ?
+## Comment contribuer ?
 
 
 Pour commencer, nous recommendons de consulter la liste des [issues](https://github.com/OpenClassrooms-Student-Center/7688581-Expert-Git-GitHub/issues)   

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ C'est grâce à ce genre d'investissement que nous pourrons favoriser un covoitu
 
 Open Transport recherche des contributeurs pour tous types de tâches : améliorations, correction de bugs, nouvelles fonctionnalités.
 
-## Comment contribuer au projet ?
+## Comment contribuer à ce nouveau projet ?
 
 
 Pour commencer, nous recommendons de consulter la liste des [issues](https://github.com/OpenClassrooms-Student-Center/7688581-Expert-Git-GitHub/issues)   

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A définir : expliquer comment executer les tests
 ```
 
 
-## Deployment
+## Déploiement
 
 Voici les étapes à suivre pour déployer en production :
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Merci de lire les fichiers :
 
 ## Auteurs
 
-* **Non spécifié**
+* **O.C.**
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Application web pour covoiturage. 
 
-## Getting started
+## Pour démarrer
 
 Ces instructions permettent d'executer une copie du projet en local sur votre poste de travail pour le développement et les tests. Référez-vous à la section "Déploiement" pour les étapes à suivre pour déployer le projet en production.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Application web pour covoiturage. 
 
-## Getting Started
+## Getting started
 
 Ces instructions permettent d'executer une copie du projet en local sur votre poste de travail pour le développement et les tests. Référez-vous à la section "Déploiement" pour les étapes à suivre pour déployer le projet en production.
 
@@ -21,7 +21,8 @@ Voici les étapes à suivre pour avoir un environnement de développement et de 
 
 
 ```
-A définir
+- Etape 1 : ...  
+- Etape 2 : ...
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,6 @@ Application web pour covoiturage.
 
 Ces instructions permettent d'executer une copie du projet en local sur votre poste de travail pour le développement et les tests. Référez-vous à la section "Déploiement" pour les étapes à suivre pour déployer le projet en production.
 
-### Pré-requis
-
-Pour executer en local le projet Open Transport, vous devez au préalable installer :
-
-```
-A définir
-
-```
-
 ### Installation
 
 Voici les étapes à suivre pour avoir un environnement de développement et de test opérationnel :

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Voici les étapes à suivre pour avoir un environnement de développement et de 
 Voici les étapes à suivre pour déployer en production :
 
 ```
-A définir
+- Etape 1 : ...  
+- Etape 2 : ...
 ```
 
 ## Technologies :

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Voici les étapes à suivre pour avoir un environnement de développement et de 
 ## Executer les tests
 
 ```
-A définir : expliquer comment executer les tests
+- Etape 1 : ...  
+- Etape 2 : ...
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ Merci de lire les fichiers :
 
 ## License
 
-Ce projet est sous la licence GNU GPL V3 - voir le fichier [LICENSE](LICENSE) pour plus de détails
+Ce projet est sous la licence GNU GPL V3 - voir le fichier [LICENSE](https://github.com/OpenClassrooms-Student-Center/7688581-Expert-Git-GitHub/blob/main/LICENSE) pour plus de détails


### PR DESCRIPTION
Correction d'une faute de frappe dans le titre de la section "Déploiement" du fichier README.md.    
Cette correction répond à l'issue #1.